### PR TITLE
fix: include original path in checkpath failure messages

### DIFF
--- a/traversal/traversal.go
+++ b/traversal/traversal.go
@@ -75,15 +75,16 @@ type TraversalResult struct {
 // expectedPath does not match the prefix of the lastPath, or lastPath is
 // shorter than expectedPath, an error will be returned.
 func CheckPath(expectPath datamodel.Path, lastPath datamodel.Path) error {
-	for expectPath.Len() > 0 {
+	p := expectPath
+	for p.Len() > 0 {
 		if lastPath.Len() == 0 {
-			return fmt.Errorf("failed to traverse full path, missed: [%s]", expectPath.String())
+			return fmt.Errorf("failed to traverse full path [%s], missed: [%s]", expectPath.String(), p.String())
 		}
 		var seg, lastSeg datamodel.PathSegment
-		seg, expectPath = expectPath.Shift()
+		seg, p = p.Shift()
 		lastSeg, lastPath = lastPath.Shift()
 		if seg != lastSeg {
-			return fmt.Errorf("unexpected path segment visit, got [%s], expected [%s]", lastSeg.String(), seg.String())
+			return fmt.Errorf("unexpected segment visit in path [%s], got [%s], expected [%s]", expectPath.String(), lastSeg.String(), seg.String())
 		}
 	}
 	// having lastPath.Len()>0 is fine, it may be due to an "all" or

--- a/traversal/traversal_test.go
+++ b/traversal/traversal_test.go
@@ -931,12 +931,12 @@ func makeCarStream(
 
 func TestCheckPath(t *testing.T) {
 	require.NoError(t, traversal.CheckPath(datamodel.ParsePath(""), datamodel.ParsePath("")))
-	require.ErrorContains(t, traversal.CheckPath(datamodel.ParsePath("a"), datamodel.ParsePath("")), "failed to traverse full path, missed: [a]")
+	require.ErrorContains(t, traversal.CheckPath(datamodel.ParsePath("a"), datamodel.ParsePath("")), "failed to traverse full path [a], missed: [a]")
 	require.NoError(t, traversal.CheckPath(datamodel.ParsePath(""), datamodel.ParsePath("a")))
 	require.NoError(t, traversal.CheckPath(datamodel.ParsePath("a/b/c"), datamodel.ParsePath("a/b/c")))
-	require.ErrorContains(t, traversal.CheckPath(datamodel.ParsePath("a/b/c/d"), datamodel.ParsePath("a/b/c")), "failed to traverse full path, missed: [d]")
+	require.ErrorContains(t, traversal.CheckPath(datamodel.ParsePath("a/b/c/d"), datamodel.ParsePath("a/b/c")), "failed to traverse full path [a/b/c/d], missed: [d]")
 	require.NoError(t, traversal.CheckPath(datamodel.ParsePath("a/b/c"), datamodel.ParsePath("a/b/c/d")))
-	require.ErrorContains(t, traversal.CheckPath(datamodel.ParsePath("a/b/c"), datamodel.ParsePath("wot/?")), "unexpected path segment visit, got [wot], expected [a]")
+	require.ErrorContains(t, traversal.CheckPath(datamodel.ParsePath("a/b/c"), datamodel.ParsePath("wot/?")), "unexpected segment visit in path [a/b/c], got [wot], expected [a]")
 }
 
 type expectedBlock struct {


### PR DESCRIPTION
decided that these messages aren't quite as interesting unless you see the original path