### PR TITLE
fix(http): honour format parameter with wildcard Accept headers

### DIFF
--- a/http/parse_test.go
+++ b/http/parse_test.go
@@ -123,9 +123,15 @@ func TestCheckFormat(t *testing.T) {
 		{"accept no dups", "application/vnd.ipld.car; dups=n", "", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithDuplicates(false)}, ""},
 		{"accept no dups and cruft", "application/vnd.ipld.car; dups=n; bip; bop", "", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithDuplicates(false)}, ""},
 		{"valid accept but format=bop (err)", "application/vnd.ipld.car; dups=y", "format=bop", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType()}, "invalid format parameter; unsupported: \"bop\""},
-		{"valid accept but format=car", "application/vnd.ipld.car; dups=y", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType()}, ""},
-		{"invalid accept but format=car", "application/vnd.ipld.car; dups=YES!", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithDuplicates(false)}, "invalid Accept header; unsupported"},
-		{"invalid accept but format=raw", "application/vnd.ipld.car; dups=YES!", "format=raw", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithMimeType(trustlesshttp.MimeTypeRaw)}, "invalid Accept header; unsupported"},
+		{"specific accept car with format=car (accept wins per spec)", "application/vnd.ipld.car; dups=y", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType()}, ""},
+		{"specific accept car with format=raw (accept wins per spec)", "application/vnd.ipld.car; dups=n", "format=raw", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithDuplicates(false)}, ""},
+		{"specific accept raw with format=car (accept wins per spec)", "application/vnd.ipld.raw", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithMimeType(trustlesshttp.MimeTypeRaw)}, ""},
+		{"invalid accept but format=car (format wins)", "application/vnd.ipld.car; dups=YES!", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType()}, ""},
+		{"invalid accept but format=raw (format wins)", "application/vnd.ipld.car; dups=YES!", "format=raw", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithMimeType(trustlesshttp.MimeTypeRaw)}, ""},
+		{"wildcard */* with format=raw (format wins)", "*/*", "format=raw", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithMimeType(trustlesshttp.MimeTypeRaw)}, ""},
+		{"wildcard */* with format=car (format wins)", "*/*", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType()}, ""},
+		{"wildcard application/* with format=raw (format wins)", "application/*", "format=raw", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithMimeType(trustlesshttp.MimeTypeRaw)}, ""},
+		{"wildcard application/* with format=car (format wins)", "application/*", "format=car", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType()}, ""},
 		{"ordered, valid", "application/vnd.ipld.raw, application/*, application/vnd.ipld.car; dups=y", "", []trustlesshttp.ContentType{trustlesshttp.DefaultContentType().WithMimeType(trustlesshttp.MimeTypeRaw), trustlesshttp.DefaultContentType().WithMimeType("application/*"), trustlesshttp.DefaultContentType().WithDuplicates(true)}, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
When both Accept header and format query parameter are present, the spec states Accept should take precedence. However, wildcard Accept headers (*/* and application/*) are now treated as having no format preference, allowing the explicit format parameter to determine the response type.

This fixes HEAD requests with ?format=raw returning CAR content-type when clients send Accept: */*.

Changes:
- Treat wildcard Accept as no preference in CheckFormat()
- Maintain spec compliance: specific Accept headers still win
- Lenient with malformed Accept + format combinations
- Add tests for wildcard + format scenarios